### PR TITLE
kill jobs implementation

### DIFF
--- a/src/main/java/fr/insalyon/creatis/gasw/executor/batch/BatchExecutor.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/executor/batch/BatchExecutor.java
@@ -58,8 +58,15 @@ public class BatchExecutor implements ExecutorPlugin {
 
     @Override
     public void terminate() throws GaswException {
-        manager.destroy();
-        // Gasw
-        monitor.finish();
+        try {
+            manager.stopRunner();
+
+            monitor.interrupt();
+            monitor.join();
+
+            manager.clean();
+        } catch (InterruptedException e) {
+            log.warn("Hard-kill occured!");
+        }
     }
 }

--- a/src/main/java/fr/insalyon/creatis/gasw/executor/batch/BatchMonitor.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/executor/batch/BatchMonitor.java
@@ -66,6 +66,7 @@ final public class BatchMonitor extends GaswMonitor {
             } catch (InterruptedException ex) {
                 log.error("Interrupted exception, stopping the worker!");
                 finish();
+                break;
             }
         }
     }

--- a/src/main/java/fr/insalyon/creatis/gasw/executor/batch/BatchMonitor.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/executor/batch/BatchMonitor.java
@@ -38,7 +38,8 @@ final public class BatchMonitor extends GaswMonitor {
 
     @Override
     public void run() {
-        while (!stop) {
+        while ( ! stop) {
+            verifySignaledJobs();
             try {
                 for (final BatchJob job : manager.getUnfinishedJobs()) {
                     final Job daoJob = jobDAO.getJobByID(job.getData().getJobID());

--- a/src/main/java/fr/insalyon/creatis/gasw/executor/batch/BatchMonitor.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/executor/batch/BatchMonitor.java
@@ -11,6 +11,7 @@ import fr.insalyon.creatis.gasw.execution.GaswStatus;
 import fr.insalyon.creatis.gasw.executor.batch.config.Constants;
 import fr.insalyon.creatis.gasw.executor.batch.internals.BatchJob;
 import fr.insalyon.creatis.gasw.executor.batch.internals.BatchManager;
+import fr.insalyon.creatis.gasw.executor.batch.internals.commands.RemoteCommand;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j;
@@ -102,7 +103,22 @@ final public class BatchMonitor extends GaswMonitor {
     }
 
     @Override
-    protected void kill(Job job) {}
+    protected void kill(Job job) {
+        final BatchJob batchJob = manager.getJob(job.getId());
+
+        if (batchJob != null) {
+            RemoteCommand command = batchJob.getData().getEngine().getDeleteCommand(batchJob.getData().getBatchJobID());
+
+            try {
+                command.execute(batchJob.getData().getConfig());
+                log.info("Job" + job.getId() + " successfully killed!");;
+            } catch (GaswException e) {
+                log.warn("Failed to kill job " + job.getId());
+            }
+        } else {
+            log.warn("Job " + job.getId() + " do not exist anymore!");
+        }
+    }
 
     @Override
     protected void reschedule(Job job) {}

--- a/src/main/java/fr/insalyon/creatis/gasw/executor/batch/BatchOutputParser.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/executor/batch/BatchOutputParser.java
@@ -7,8 +7,11 @@ import fr.insalyon.creatis.gasw.GaswException;
 import fr.insalyon.creatis.gasw.GaswExitCode;
 import fr.insalyon.creatis.gasw.GaswOutput;
 import fr.insalyon.creatis.gasw.execution.GaswOutputParser;
+import fr.insalyon.creatis.gasw.execution.GaswStatus;
 import fr.insalyon.creatis.gasw.executor.batch.internals.BatchJob;
+import lombok.extern.log4j.Log4j;
 
+@Log4j
 public class BatchOutputParser extends GaswOutputParser {
 
     final private BatchJob job;
@@ -22,33 +25,41 @@ public class BatchOutputParser extends GaswOutputParser {
     public GaswOutput getGaswOutput() throws GaswException {
         final File stdOut = getAppStdFile(GaswConstants.OUT_EXT, GaswConstants.OUT_ROOT);
         final File stdErr = getAppStdFile(GaswConstants.ERR_EXT, GaswConstants.ERR_ROOT);
-        GaswExitCode gaswExitCode;
+        GaswExitCode gaswExitCode = GaswExitCode.UNDEFINED;
         int exitCode;
 
         job.download();
         moveProvenanceFile(".");
 
-        exitCode = parseStdOut(stdOut);
-        exitCode = parseStdErr(stdErr, exitCode);
-
-        switch (exitCode) {
-            case 0:
-                gaswExitCode = GaswExitCode.SUCCESS;
-                break;
-            case 1:
-                gaswExitCode = GaswExitCode.ERROR_READ_GRID;
-                break;
-            case 2:
-                gaswExitCode = GaswExitCode.ERROR_WRITE_GRID;
-                break;
-            case 6:
-                gaswExitCode = GaswExitCode.EXECUTION_FAILED;
-                break;
-            case 7:
-                gaswExitCode = GaswExitCode.ERROR_WRITE_LOCAL;
-                break;
-            default:
-                gaswExitCode = GaswExitCode.UNDEFINED;
+        try {
+            if (job.getStatus() != GaswStatus.CANCELLED && job.getStatus() != GaswStatus.DELETED) {
+                exitCode = parseStdOut(stdOut);
+                exitCode = parseStdErr(stdErr, exitCode);
+        
+                switch (exitCode) {
+                    case 0:
+                        gaswExitCode = GaswExitCode.SUCCESS;
+                        break;
+                    case 1:
+                        gaswExitCode = GaswExitCode.ERROR_READ_GRID;
+                        break;
+                    case 2:
+                        gaswExitCode = GaswExitCode.ERROR_WRITE_GRID;
+                        break;
+                    case 6:
+                        gaswExitCode = GaswExitCode.EXECUTION_FAILED;
+                        break;
+                    case 7:
+                        gaswExitCode = GaswExitCode.ERROR_WRITE_LOCAL;
+                        break;
+                    default:
+                        gaswExitCode = GaswExitCode.UNDEFINED;
+                }
+            } else {
+                gaswExitCode = GaswExitCode.EXECUTION_CANCELED;
+            }
+        } catch (InterruptedException e) {
+            log.warn("Failed to retrieve gaswStatus during output parsing!");
         }
 
         return new GaswOutput(job.getData().getJobID(), gaswExitCode, "", uploadedResults,

--- a/src/main/java/fr/insalyon/creatis/gasw/executor/batch/config/json/properties/BatchEngine.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/executor/batch/config/json/properties/BatchEngine.java
@@ -3,8 +3,10 @@ package fr.insalyon.creatis.gasw.executor.batch.config.json.properties;
 import java.lang.reflect.InvocationTargetException;
 
 import fr.insalyon.creatis.gasw.executor.batch.internals.commands.RemoteCommand;
+import fr.insalyon.creatis.gasw.executor.batch.internals.commands.items.Qdel;
 import fr.insalyon.creatis.gasw.executor.batch.internals.commands.items.Qsub;
 import fr.insalyon.creatis.gasw.executor.batch.internals.commands.items.Sbatch;
+import fr.insalyon.creatis.gasw.executor.batch.internals.commands.items.Scancel;
 import fr.insalyon.creatis.gasw.executor.batch.internals.commands.items.Scontrol;
 import fr.insalyon.creatis.gasw.executor.batch.internals.commands.items.Tracejob;
 import lombok.extern.log4j.Log4j;
@@ -12,15 +14,18 @@ import lombok.extern.log4j.Log4j;
 @Log4j
 public enum BatchEngine {
 
-    SLURM(Sbatch.class, Scontrol.class),
-    PBS(Qsub.class, Tracejob.class);
+    SLURM(Sbatch.class, Scontrol.class, Scancel.class),
+    PBS(Qsub.class, Tracejob.class, Qdel.class);
 
     final private Class<? extends RemoteCommand> submit;
     final private Class<? extends RemoteCommand> status;
+    final private Class<? extends RemoteCommand> delete;
 
-    BatchEngine(Class<? extends RemoteCommand> submitCommand, Class<? extends RemoteCommand> statusCommand) {
+    BatchEngine(Class<? extends RemoteCommand> submitCommand, Class<? extends RemoteCommand> statusCommand,
+            Class<? extends RemoteCommand> deleteCommand) {
         this.submit = submitCommand;
         this.status = statusCommand;
+        this.delete = deleteCommand;
     }
 
     private RemoteCommand buidler(Class<? extends RemoteCommand> toBuild, final String data) {
@@ -39,5 +44,9 @@ public enum BatchEngine {
 
     public RemoteCommand getStatusCommand(final String data) {
         return buidler(status, data);
+    }
+
+    public RemoteCommand getDeleteCommand(final String data) {
+        return buidler(delete, data);
     }
 }

--- a/src/main/java/fr/insalyon/creatis/gasw/executor/batch/internals/commands/items/Qdel.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/executor/batch/internals/commands/items/Qdel.java
@@ -1,0 +1,15 @@
+package fr.insalyon.creatis.gasw.executor.batch.internals.commands.items;
+
+import fr.insalyon.creatis.gasw.executor.batch.internals.commands.RemoteCommand;
+
+public class Qdel extends RemoteCommand {
+
+    public Qdel(final String jobID) {
+        super("qdel " + jobID);
+    }
+
+    @Override
+    public String result() {
+        return "";
+    }
+}

--- a/src/main/java/fr/insalyon/creatis/gasw/executor/batch/internals/commands/items/Qstat.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/executor/batch/internals/commands/items/Qstat.java
@@ -1,0 +1,39 @@
+package fr.insalyon.creatis.gasw.executor.batch.internals.commands.items;
+
+import fr.insalyon.creatis.gasw.executor.batch.internals.commands.RemoteCommand;
+import fr.insalyon.creatis.gasw.executor.batch.internals.terminal.RemoteStream;
+
+public class Qstat extends RemoteCommand {
+
+    public Qstat(final String jobID) {
+        super("qstat -f " + jobID + " | grep job_state | xargs");
+    }
+
+    @Override
+    public String result() {
+        if (failed() || getOutput().getStdout().getContent().isBlank()) {
+            return "";
+        } else {
+            final RemoteStream out = getOutput().getStdout();
+
+            switch (out.getColumn(2)[0]) {
+                case "C":
+                    return "COMPLETED";
+                case "E":
+                    return "RUNNING";
+                case "H": // held
+                    return "PENDING";
+                case "Q":
+                    return "PENDING";
+                case "R":
+                    return "RUNNING";
+                case "T": // moved
+                    return "PENDING";
+                case "W":
+                    return "PENDING";
+                default:
+                    return "";
+            }
+        }
+    }
+}

--- a/src/main/java/fr/insalyon/creatis/gasw/executor/batch/internals/commands/items/Scancel.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/executor/batch/internals/commands/items/Scancel.java
@@ -1,0 +1,15 @@
+package fr.insalyon.creatis.gasw.executor.batch.internals.commands.items;
+
+import fr.insalyon.creatis.gasw.executor.batch.internals.commands.RemoteCommand;
+
+public class Scancel extends RemoteCommand {
+
+    public Scancel(final String jobID) {
+        super("scancel " + jobID);
+    }
+
+    @Override
+    public String result() {
+        return "";
+    }
+}

--- a/src/main/java/fr/insalyon/creatis/gasw/executor/batch/internals/commands/items/Tracejob.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/executor/batch/internals/commands/items/Tracejob.java
@@ -1,15 +1,39 @@
 package fr.insalyon.creatis.gasw.executor.batch.internals.commands.items;
 
+import fr.insalyon.creatis.gasw.GaswException;
+import fr.insalyon.creatis.gasw.executor.batch.config.json.properties.BatchConfig;
 import fr.insalyon.creatis.gasw.executor.batch.internals.commands.RemoteCommand;
 import fr.insalyon.creatis.gasw.executor.batch.internals.terminal.RemoteStream;
 
 public class Tracejob extends RemoteCommand {
 
+    final private Qstat subCommand;
+
+    /**
+     * Relies on a first call of qstat class because tracing is easier with qstat
+     * but it will only work if it still running. That's why the fallback is handled by 
+     * a call to the tracejob command.
+     */
     public Tracejob(final String jobID) {
         super("2>/dev/null tracejob " + jobID + " | grep state | tail -n 1 | xargs");
+        subCommand = new Qstat(jobID);
+    }
+
+    @Override
+    public RemoteCommand execute(BatchConfig config) throws GaswException {
+        subCommand.execute(config);
+        return super.execute(config);
     }
 
     public String result() {
+        if (subCommand.result().isEmpty()) {
+            return traceJobResult();
+        } else {
+            return subCommand.result();
+        }
+    }
+
+    public String traceJobResult() {
         final RemoteStream out = getOutput().getStdout();
         final String[] line = out.getRow(out.getLines().length - 1);
 

--- a/src/main/java/fr/insalyon/creatis/gasw/executor/batch/internals/terminal/RemoteTerminal.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/executor/batch/internals/terminal/RemoteTerminal.java
@@ -119,7 +119,7 @@ public class RemoteTerminal {
             channel.setErr(stderr);
 
             channel.open().verify(config.getOptions().getCommandExecutionTimeout(), TimeUnit.SECONDS);
-            channel.waitFor(EnumSet.of(ClientChannelEvent.CLOSED), config.getOptions().getSshEventTimeout());
+            channel.waitFor(EnumSet.of(ClientChannelEvent.CLOSED, ClientChannelEvent.EXIT_STATUS), config.getOptions().getSshEventTimeout());
 
             return new RemoteOutput(stdout.toString(), stderr.toString(), channel.getExitStatus());
         } catch (IOException e) {


### PR DESCRIPTION
- adding support for kill methods on pbs/slurm (also added missing `verifySignaledJobs()` method from Gasw)
- fixing pbs `getStatus()` by mixing up `qstat` and `tracejob` commands (**qstat** do not works when the job is ended, but **tracejob** won't work very well when the job is running. That's why we need to switch between them depending on which state is the job).